### PR TITLE
Added executable product to let it be used with Mint (https://github.com/yonaskolb/Mint).

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,9 @@ let package = Package(
     platforms: [
         .macOS(.v11)
     ],
+    products: [
+        .executable(name: "arm64-to-sim", targets: ["arm64-to-sim"])
+    ],
     dependencies: [
     ],
     targets: [


### PR DESCRIPTION
This would let you run the tool without checking it out and manually building, as long as you have Mint installed, like this:

`mint run bogo/arm64-to-sim@main /tmp/libAWSCognitoIdentityProviderASFBinary.a`

At the moment Mint complains about missing executable `.product` in the package description:

```
$ mint run bogo/arm64-to-sim@main /tmp/libAWSCognitoIdentityProviderASFBinary.a
🌱 Cloning arm64-to-sim main
🌱 Resolving package
🌱  Executable product not found in arm64-to-sim main
```
