### PR TITLE
exclude all ZEROFILL types from offset patching

### DIFF
--- a/Sources/arm64-to-sim/main.swift
+++ b/Sources/arm64-to-sim/main.swift
@@ -81,11 +81,16 @@ enum Transmogrifier {
         segment.vmsize += UInt64(offset)
         
         let offsetSections = sections.map { section -> section_64 in
-            var section = section
-            if section.flags != S_ZEROFILL {
-                section.offset += UInt32(offset)
-                section.reloff += section.reloff > 0 ? UInt32(offset) : 0
+            let sectionType = Int32(section.flags) & SECTION_TYPE
+            switch sectionType {
+            case S_ZEROFILL, S_GB_ZEROFILL, S_THREAD_LOCAL_ZEROFILL:
+                return section
+            case _: break
             }
+                                           
+            var section = section            
+            section.offset += UInt32(offset)
+            section.reloff += section.reloff > 0 ? UInt32(offset) : 0
             return section
         }
         


### PR DESCRIPTION
S_GB_ZEROFILL and S_THREAD_LOCAL_ZEROFILL should also be excluded from offset patching. Besides, section.flags should not be compared directly with the section type constants as it may contain the optional section attributes.