### PR TITLE
Increase type width to fix 'Fatal error: Not enough bits to represent the passed value'

### DIFF
--- a/Sources/Arm64ToSimLib/Transmogrifier.swift
+++ b/Sources/Arm64ToSimLib/Transmogrifier.swift
@@ -81,9 +81,9 @@ public enum Transmogrifier {
         segment.vmsize += UInt64(offset)
 
         let offsetSections = sections.map { section -> section_64 in
-            let sectionType = Int32(section.flags) & SECTION_TYPE
+            let sectionType = Int64(section.flags) & Int64(SECTION_TYPE)
             switch sectionType {
-            case S_ZEROFILL, S_GB_ZEROFILL, S_THREAD_LOCAL_ZEROFILL:
+            case Int64(S_ZEROFILL), Int64(S_GB_ZEROFILL), Int64(S_THREAD_LOCAL_ZEROFILL):
                 return section
             case _: break
             }


### PR DESCRIPTION
Hi there,

First of all, excellent work on this tool and the associated articles! I successfully used this to convert some of our frameworks. However, when running the tool I got `Fatal error: Not enough bits to represent the passed value` errors on my `Apple M1 Pro` MBP. 

I tried this solution out (increase to 64-bit types) and it seems to have worked fine. So, posting this here. I can also check things for you if that helps.

Thanks