### PR TITLE
Fix overflow when serializing the `sectionType`

### DIFF
--- a/Sources/Arm64ToSimLib/Transmogrifier.swift
+++ b/Sources/Arm64ToSimLib/Transmogrifier.swift
@@ -81,8 +81,8 @@ public enum Transmogrifier {
         segment.vmsize += UInt64(offset)
 
         let offsetSections = sections.map { section -> section_64 in
-            let sectionType = Int32(section.flags) & SECTION_TYPE
-            switch sectionType {
+            let sectionType = section.flags & UInt32(SECTION_TYPE)
+            switch Int32(sectionType) {
             case S_ZEROFILL, S_GB_ZEROFILL, S_THREAD_LOCAL_ZEROFILL:
                 return section
             case _: break


### PR DESCRIPTION
The struct, `section_64`'s field `flags` is a `UInt32` and the current
code can overflow because of the cast. Swift catches the runtime failure
and crashes.

I have attached culprit object file's header info but can't reproduce or
provide the object file which compiled on Xcode 12.1.

```
Some.o:
Load command 0
      cmd LC_SEGMENT_64
  cmdsize 1832
  segname
   vmaddr 0x0000000000000000
   vmsize 0x0000000000001135
  fileoff 2648
 filesize 4405
  maxprot 0x00000007
 initprot 0x00000007
   nsects 22
    flags 0x0
```

```
Load command 1
      cmd LC_VERSION_MIN_IPHONEOS
  cmdsize 16
  version 9.3
      sdk 14.1
```