### PR TITLE
Handle when "build_version_command.ntools!=0"

### DIFF
--- a/Sources/Arm64ToSimLib/Transmogrifier.swift
+++ b/Sources/Arm64ToSimLib/Transmogrifier.swift
@@ -148,11 +148,6 @@ public enum Transmogrifier {
         return Data(bytes: &command, count: data.commandSize)
     }
 
-    private static func updateDynamicSymTab(_ data: Data, _ offset: UInt32) -> Data {
-        var command: dysymtab_command = data.asStruct()
-        return Data(bytes: &command, count: data.commandSize)
-    }
-
   private static func computeLoadCommandsEditor(_ loadCommandsData: [Data], isDynamic: Bool) -> ((Data, UInt32, UInt32) -> Data) {
 
     if isDynamic {
@@ -215,8 +210,6 @@ public enum Transmogrifier {
               return updateSymTab(lc, offset)
           case LC_BUILD_VERSION:
               return updateVersionMin(lc, offset, minos: minos, sdk: sdk)
-        //   case LC_DYSYMTAB:
-        //       return updateDynamicSymTab(lc, offset)
           default:
               return lc
       }


### PR DESCRIPTION
**Background**
Previous implementation was not supporting for case when `build_version_command.ntools != 0` because ntools was hardcoded to 0. 

**Changes**
Based on [how MachO files are loaded in dyld](https://opensource.apple.com/source/dyld/dyld-655.1.1/dyld3/MachOLoaded.cpp.auto.html) (attached below)
```
case LC_BUILD_VERSION:
    if ( cmd->cmdsize != (sizeof(build_version_command) + ((build_version_command*)cmd)->ntools * sizeof(build_tool_version)) )
        diag.error("LC_BUILD_VERSION load command size wrong");
    else if ( hasMinVersion )
        diag.error("LC_BUILD_VERSION cannot coexist LC_VERSION_MIN_* with load commands");
    break;
``` 
Add a similar logic into function [updateVersionMin](https://github.com/bogo/arm64-to-sim/pull/17/files#diff-2fa3a35d0a05971acae9bd452728627eced32af032e57a2362646458b9fa691dR107). 